### PR TITLE
Skip fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tags
+.idea

--- a/handy.go
+++ b/handy.go
@@ -12,7 +12,7 @@ var handyPool ParserPool
 // Parser is faster for obtaining multiple fields from JSON.
 func GetString(data []byte, keys ...string) string {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return ""
@@ -33,7 +33,7 @@ func GetString(data []byte, keys ...string) string {
 // Parser is faster for obtaining multiple fields from JSON.
 func GetBytes(data []byte, keys ...string) []byte {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return nil
@@ -60,7 +60,7 @@ func GetBytes(data []byte, keys ...string) []byte {
 // Parser is faster for obtaining multiple fields from JSON.
 func GetInt(data []byte, keys ...string) int {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return 0
@@ -80,7 +80,7 @@ func GetInt(data []byte, keys ...string) int {
 // Parser is faster for obtaining multiple fields from JSON.
 func GetFloat64(data []byte, keys ...string) float64 {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return 0
@@ -100,7 +100,7 @@ func GetFloat64(data []byte, keys ...string) float64 {
 // Parser is faster for obtaining multiple fields from JSON.
 func GetBool(data []byte, keys ...string) bool {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return false
@@ -119,7 +119,7 @@ func GetBool(data []byte, keys ...string) bool {
 // Parser is faster when multiple fields must be checked in the JSON.
 func Exists(data []byte, keys ...string) bool {
 	p := handyPool.Get()
-	v, err := p.ParseBytes(data)
+	v, err := p.ParseBytes(data, nil)
 	if err != nil {
 		handyPool.Put(p)
 		return false
@@ -134,7 +134,7 @@ func Exists(data []byte, keys ...string) bool {
 // The function is slower than the Parser.Parse for re-used Parser.
 func Parse(s string) (*Value, error) {
 	var p Parser
-	return p.Parse(s)
+	return p.Parse(s, nil)
 }
 
 // MustParse parses json string s.
@@ -154,7 +154,7 @@ func MustParse(s string) *Value {
 // The function is slower than the Parser.ParseBytes for re-used Parser.
 func ParseBytes(b []byte) (*Value, error) {
 	var p Parser
-	return p.ParseBytes(b)
+	return p.ParseBytes(b, nil)
 }
 
 // MustParseBytes parses b containing json.

--- a/parser_example_test.go
+++ b/parser_example_test.go
@@ -9,7 +9,7 @@ import (
 
 func ExampleParser_Parse() {
 	var p fastjson.Parser
-	v, err := p.Parse(`{"foo":"bar", "baz": 123}`)
+	v, err := p.Parse(`{"foo":"bar", "baz": 123}`, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}
@@ -32,7 +32,7 @@ func ExampleParser_Parse_reuse() {
 
 	for i := 0; i < 3; i++ {
 		s := fmt.Sprintf(`["foo_%d","bar_%d","%d"]`, i, i, i)
-		v, err := p.Parse(s)
+		v, err := p.Parse(s, nil)
 		if err != nil {
 			log.Fatalf("cannot parse json: %s", err)
 		}
@@ -62,7 +62,7 @@ func ExampleValue_MarshalTo() {
 		]
 	}`
 	var p fastjson.Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}
@@ -83,7 +83,7 @@ func ExampleValue_MarshalTo() {
 func ExampleValue_Get() {
 	s := `{"foo":[{"bar":{"baz":123,"x":"434"},"y":[]},[null, false]],"qwe":true}`
 	var p fastjson.Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}
@@ -124,7 +124,7 @@ func ExampleValue_Type() {
 	}`
 
 	var p fastjson.Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}
@@ -155,7 +155,7 @@ func ExampleObject_Visit() {
 	}`
 
 	var p fastjson.Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}
@@ -188,7 +188,7 @@ func ExampleValue_GetStringBytes() {
 	]`
 
 	var p fastjson.Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		log.Fatalf("cannot parse json: %s", err)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -181,7 +181,7 @@ func TestParserPool(t *testing.T) {
 	var pp ParserPool
 	for i := 0; i < 10; i++ {
 		p := pp.Get()
-		if _, err := p.Parse("null"); err != nil {
+		if _, err := p.Parse("null", nil); err != nil {
 			t.Fatalf("cannot parse null: %s", err)
 		}
 		pp.Put(p)
@@ -191,7 +191,7 @@ func TestParserPool(t *testing.T) {
 func TestValueInvalidTypeConversion(t *testing.T) {
 	var p Parser
 
-	v, err := p.Parse(`[{},[],"",123.45,true,null]`)
+	v, err := p.Parse(`[{},[],"",123.45,true,null]`, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -279,7 +279,7 @@ func TestValueGetTyped(t *testing.T) {
 		"inf_float": Inf,
 		"minus_inf_float": -Inf,
 		"nan": nan
-	}`)
+	}`, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -432,7 +432,7 @@ func TestValueGetTyped(t *testing.T) {
 
 func TestVisitNil(t *testing.T) {
 	var p Parser
-	v, err := p.Parse(`{}`)
+	v, err := p.Parse(`{}`, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -449,7 +449,7 @@ func TestValueGet(t *testing.T) {
 	var pp ParserPool
 
 	p := pp.Get()
-	v, err := p.ParseBytes([]byte(`{"xx":33.33,"foo":[123,{"bar":["baz"],"x":"y"}], "": "empty-key", "empty-value": ""}`))
+	v, err := p.ParseBytes([]byte(`{"xx":33.33,"foo":[123,{"bar":["baz"],"x":"y"}], "": "empty-key", "empty-value": ""}`), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -532,7 +532,7 @@ func TestParserParse(t *testing.T) {
 	var p Parser
 
 	t.Run("complex-string", func(t *testing.T) {
-		v, err := p.Parse(`{"тест":1, "\\\"фыва\"":2, "\\\"\u1234x":"\\fЗУ\\\\"}`)
+		v, err := p.Parse(`{"тест":1, "\\\"фыва\"":2, "\\\"\u1234x":"\\fЗУ\\\\"}`, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -551,7 +551,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("invalid-string-escape", func(t *testing.T) {
-		v, err := p.Parse(`"fo\u"`)
+		v, err := p.Parse(`"fo\u"`, nil)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing string")
 		}
@@ -564,7 +564,7 @@ func TestParserParse(t *testing.T) {
 			t.Fatalf("unexpected string; got %q; want %q", sb, "fo\\u")
 		}
 
-		v, err = p.Parse(`"foo\ubarz2134"`)
+		v, err = p.Parse(`"foo\ubarz2134"`, nil)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing string")
 		}
@@ -576,7 +576,7 @@ func TestParserParse(t *testing.T) {
 			t.Fatalf("unexpected string; got %q; want %q", sb, "foo")
 		}
 
-		v, err = p.Parse(`"fo` + "\x19" + `\u"`)
+		v, err = p.Parse(`"fo`+"\x19"+`\u"`, nil)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing string")
 		}
@@ -590,7 +590,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("invalid-number", func(t *testing.T) {
-		v, err := p.Parse("123+456")
+		v, err := p.Parse("123+456", nil)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing int")
 		}
@@ -606,22 +606,22 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("empty-json", func(t *testing.T) {
-		_, err := p.Parse("")
+		_, err := p.Parse("", nil)
 		if err == nil {
 			t.Fatalf("expecting non-nil error when parsing empty json")
 		}
-		_, err = p.Parse("\n\t    \n")
+		_, err = p.Parse("\n\t    \n", nil)
 		if err == nil {
 			t.Fatalf("expecting non-nil error when parsing empty json")
 		}
 	})
 
 	t.Run("invalid-tail", func(t *testing.T) {
-		_, err := p.Parse("123 456")
+		_, err := p.Parse("123 456", nil)
 		if err == nil {
 			t.Fatalf("expecting non-nil error when parsing invalid tail")
 		}
-		_, err = p.Parse("[] 1223")
+		_, err = p.Parse("[] 1223", nil)
 		if err == nil {
 			t.Fatalf("expecting non-nil error when parsing invalid tail")
 		}
@@ -630,7 +630,7 @@ func TestParserParse(t *testing.T) {
 	t.Run("invalid-json", func(t *testing.T) {
 		f := func(s string) {
 			t.Helper()
-			if _, err := p.Parse(s); err == nil {
+			if _, err := p.Parse(s, nil); err == nil {
 				t.Fatalf("expecting non-nil error when parsing invalid json %q", s)
 			}
 		}
@@ -651,7 +651,7 @@ func TestParserParse(t *testing.T) {
 		f(`{"foo":123 "bar":"baz"}`)
 		f("-2134.453eec+43")
 
-		if _, err := p.Parse("-2134.453E+43"); err != nil {
+		if _, err := p.Parse("-2134.453E+43", nil); err != nil {
 			t.Fatalf("unexpected error when parsing number: %s", err)
 		}
 
@@ -661,7 +661,7 @@ func TestParserParse(t *testing.T) {
 		// Incomplete string.
 		f(`"{\"foo\": 123}`)
 
-		v, err := p.Parse(`"{\"foo\": 123}"`)
+		v, err := p.Parse(`"{\"foo\": 123}"`, nil)
 		if err != nil {
 			t.Fatalf("unexpected error when parsing json string: %s", err)
 		}
@@ -674,7 +674,7 @@ func TestParserParse(t *testing.T) {
 	t.Run("incomplete-object", func(t *testing.T) {
 		f := func(s string) {
 			t.Helper()
-			if _, err := p.Parse(s); err == nil {
+			if _, err := p.Parse(s, nil); err == nil {
 				t.Fatalf("expecting non-nil error when parsing incomplete object %q", s)
 			}
 		}
@@ -687,7 +687,7 @@ func TestParserParse(t *testing.T) {
 		f(`{"foo":null,}`)
 		f(`{"foo":null,"bar"}`)
 
-		if _, err := p.Parse(`{"foo":null,"bar":"baz"}`); err != nil {
+		if _, err := p.Parse(`{"foo":null,"bar":"baz"}`, nil); err != nil {
 			t.Fatalf("unexpected error when parsing object: %s", err)
 		}
 	})
@@ -695,7 +695,7 @@ func TestParserParse(t *testing.T) {
 	t.Run("incomplete-array", func(t *testing.T) {
 		f := func(s string) {
 			t.Helper()
-			if _, err := p.Parse(s); err == nil {
+			if _, err := p.Parse(s, nil); err == nil {
 				t.Fatalf("expecting non-nil error when parsing incomplete array %q", s)
 			}
 		}
@@ -707,7 +707,7 @@ func TestParserParse(t *testing.T) {
 		f("[123,{}")
 		f("[123,{},]")
 
-		if _, err := p.Parse("[123,{},[]]"); err != nil {
+		if _, err := p.Parse("[123,{},[]]", nil); err != nil {
 			t.Fatalf("unexpected error when parsing array: %s", err)
 		}
 	})
@@ -715,7 +715,7 @@ func TestParserParse(t *testing.T) {
 	t.Run("incomplete-string", func(t *testing.T) {
 		f := func(s string) {
 			t.Helper()
-			if _, err := p.Parse(s); err == nil {
+			if _, err := p.Parse(s, nil); err == nil {
 				t.Fatalf("expecting non-nil error when parsing incomplete string %q", s)
 			}
 		}
@@ -727,13 +727,13 @@ func TestParserParse(t *testing.T) {
 		f(`"foo'`)
 		f(`"foo'bar'`)
 
-		if _, err := p.Parse(`"foo\\\""`); err != nil {
+		if _, err := p.Parse(`"foo\\\""`, nil); err != nil {
 			t.Fatalf("unexpected error when parsing string: %s", err)
 		}
 	})
 
 	t.Run("empty-object", func(t *testing.T) {
-		v, err := p.Parse("{}")
+		v, err := p.Parse("{}", nil)
 		if err != nil {
 			t.Fatalf("cannot parse empty object: %s", err)
 		}
@@ -756,7 +756,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("empty-array", func(t *testing.T) {
-		v, err := p.Parse("[]")
+		v, err := p.Parse("[]", nil)
 		if err != nil {
 			t.Fatalf("cannot parse empty array: %s", err)
 		}
@@ -779,7 +779,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("null", func(t *testing.T) {
-		v, err := p.Parse("null")
+		v, err := p.Parse("null", nil)
 		if err != nil {
 			t.Fatalf("cannot parse null: %s", err)
 		}
@@ -794,7 +794,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("true", func(t *testing.T) {
-		v, err := p.Parse("true")
+		v, err := p.Parse("true", nil)
 		if err != nil {
 			t.Fatalf("cannot parse true: %s", err)
 		}
@@ -816,7 +816,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("false", func(t *testing.T) {
-		v, err := p.Parse("false")
+		v, err := p.Parse("false", nil)
 		if err != nil {
 			t.Fatalf("cannot parse false: %s", err)
 		}
@@ -838,7 +838,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("integer", func(t *testing.T) {
-		v, err := p.Parse("12345")
+		v, err := p.Parse("12345", nil)
 		if err != nil {
 			t.Fatalf("cannot parse integer: %s", err)
 		}
@@ -860,7 +860,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("int64", func(t *testing.T) {
-		v, err := p.Parse("-8838840643388017390")
+		v, err := p.Parse("-8838840643388017390", nil)
 		if err != nil {
 			t.Fatalf("cannot parse int64: %s", err)
 		}
@@ -882,7 +882,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("uint", func(t *testing.T) {
-		v, err := p.Parse("18446744073709551615")
+		v, err := p.Parse("18446744073709551615", nil)
 		if err != nil {
 			t.Fatalf("cannot parse uint: %s", err)
 		}
@@ -904,7 +904,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("uint64", func(t *testing.T) {
-		v, err := p.Parse("18446744073709551615")
+		v, err := p.Parse("18446744073709551615", nil)
 		if err != nil {
 			t.Fatalf("cannot parse uint64: %s", err)
 		}
@@ -926,7 +926,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("float", func(t *testing.T) {
-		v, err := p.Parse("-12.345")
+		v, err := p.Parse("-12.345", nil)
 		if err != nil {
 			t.Fatalf("cannot parse integer: %s", err)
 		}
@@ -948,7 +948,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("string", func(t *testing.T) {
-		v, err := p.Parse(`"foo bar"`)
+		v, err := p.Parse(`"foo bar"`, nil)
 		if err != nil {
 			t.Fatalf("cannot parse string: %s", err)
 		}
@@ -970,7 +970,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("string-escaped", func(t *testing.T) {
-		v, err := p.Parse(`"\n\t\\foo\"bar\u3423x\/\b\f\r\\"`)
+		v, err := p.Parse(`"\n\t\\foo\"bar\u3423x\/\b\f\r\\"`, nil)
 		if err != nil {
 			t.Fatalf("cannot parse string: %s", err)
 		}
@@ -993,7 +993,7 @@ func TestParserParse(t *testing.T) {
 
 	t.Run("object-one-element", func(t *testing.T) {
 		v, err := p.Parse(`  {
-	"foo"   : "bar"  }	 `)
+	"foo"   : "bar"  }	 `, nil)
 		if err != nil {
 			t.Fatalf("cannot parse object: %s", err)
 		}
@@ -1021,7 +1021,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("object-multi-elements", func(t *testing.T) {
-		v, err := p.Parse(`{"foo": [1,2,3  ]  ,"bar":{},"baz":123.456}`)
+		v, err := p.Parse(`{"foo": [1,2,3  ]  ,"bar":{},"baz":123.456}`, nil)
 		if err != nil {
 			t.Fatalf("cannot parse object: %s", err)
 		}
@@ -1057,7 +1057,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("array-one-element", func(t *testing.T) {
-		v, err := p.Parse(`   [{"bar":[  [],[[]]   ]} ]  `)
+		v, err := p.Parse(`   [{"bar":[  [],[[]]   ]} ]  `, nil)
 		if err != nil {
 			t.Fatalf("cannot parse array: %s", err)
 		}
@@ -1083,7 +1083,7 @@ func TestParserParse(t *testing.T) {
 	})
 
 	t.Run("array-multi-elements", func(t *testing.T) {
-		v, err := p.Parse(`   [1,"foo",{"bar":[     ],"baz":""}    ,[  "x" ,	"y"   ]     ]   `)
+		v, err := p.Parse(`   [1,"foo",{"bar":[     ],"baz":""}    ,[  "x" ,	"y"   ]     ]   `, nil)
 		if err != nil {
 			t.Fatalf("cannot parse array: %s", err)
 		}
@@ -1119,7 +1119,7 @@ func TestParserParse(t *testing.T) {
 
 	t.Run("complex-object", func(t *testing.T) {
 		s := `{"foo":[-1.345678,[[[[[]]]],{}],"bar"],"baz":{"bbb":123}}`
-		v, err := p.Parse(s)
+		v, err := p.Parse(s, nil)
 		if err != nil {
 			t.Fatalf("cannot parse complex object: %s", err)
 		}
@@ -1133,7 +1133,7 @@ func TestParserParse(t *testing.T) {
 		}
 
 		s = strings.TrimSpace(largeFixture)
-		v, err = p.Parse(s)
+		v, err = p.Parse(s, nil)
 		if err != nil {
 			t.Fatalf("cannot parse largeFixture: %s", err)
 		}
@@ -1178,7 +1178,7 @@ func TestParserParse(t *testing.T) {
 		}
 
 		s := strings.TrimSpace(largeFixture)
-		v, err := p.Parse(s)
+		v, err := p.Parse(s, nil)
 		if err != nil {
 			t.Fatalf("cannot parse largeFixture: %s", err)
 		}
@@ -1214,7 +1214,7 @@ func TestParseBigObject(t *testing.T) {
 
 	// parse it
 	var p Parser
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1260,7 +1260,7 @@ func TestParseGetConcurrent(t *testing.T) {
 func testParseGetSerial(s string) error {
 	var p Parser
 	for i := 0; i < 100; i++ {
-		v, err := p.Parse(s)
+		v, err := p.Parse(s, nil)
 		if err != nil {
 			return fmt.Errorf("cannot parse %q: %s", s, err)
 		}

--- a/parser_timing_test.go
+++ b/parser_timing_test.go
@@ -92,7 +92,7 @@ func benchmarkObjectGet(b *testing.B, itemsCount, lookupsCount int) {
 	b.RunParallel(func(pb *testing.PB) {
 		p := benchPool.Get()
 		for pb.Next() {
-			v, err := p.Parse(s)
+			v, err := p.Parse(s, nil)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))
 			}
@@ -131,7 +131,7 @@ func BenchmarkMarshalTo(b *testing.B) {
 
 func benchmarkMarshalTo(b *testing.B, s string) {
 	p := benchPool.Get()
-	v, err := p.Parse(s)
+	v, err := p.Parse(s, nil)
 	if err != nil {
 		panic(fmt.Errorf("unexpected error: %s", err))
 	}
@@ -167,6 +167,26 @@ func BenchmarkParse(b *testing.B) {
 	})
 	b.Run("twitter", func(b *testing.B) {
 		benchmarkParse(b, twitterFixture)
+	})
+}
+
+func BenchmarkSkip(b *testing.B) {
+	b.Run("fastjson", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(citmFixture)))
+		b.RunParallel(func(pb *testing.PB) {
+			p := benchPool.Get()
+			for pb.Next() {
+				v, err := p.Parse(citmFixture, nil)
+				if err != nil {
+					panic(fmt.Errorf("unexpected error: %s", err))
+				}
+				if v.Type() != TypeObject {
+					panic(fmt.Errorf("unexpected value type; got %s; want %s", v.Type(), TypeObject))
+				}
+			}
+			benchPool.Put(p)
+		})
 	})
 }
 
@@ -214,7 +234,7 @@ func benchmarkFastJSONParse(b *testing.B, s string) {
 	b.RunParallel(func(pb *testing.PB) {
 		p := benchPool.Get()
 		for pb.Next() {
-			v, err := p.Parse(s)
+			v, err := p.Parse(s, nil)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))
 			}
@@ -233,7 +253,7 @@ func benchmarkFastJSONParseGet(b *testing.B, s string) {
 		p := benchPool.Get()
 		var n int
 		for pb.Next() {
-			v, err := p.Parse(s)
+			v, err := p.Parse(s, nil)
 			if err != nil {
 				panic(fmt.Errorf("unexpected error: %s", err))
 			}

--- a/scanner.go
+++ b/scanner.go
@@ -65,7 +65,7 @@ func (sc *Scanner) Next() bool {
 	}
 
 	sc.c.reset()
-	v, tail, err := parseValue(sc.s, &sc.c, 0)
+	v, tail, err := parseValue(sc.s, &sc.c, 0, false, nil)
 	if err != nil {
 		sc.err = err
 		return false

--- a/update_test.go
+++ b/update_test.go
@@ -10,7 +10,7 @@ func TestObjectDelSet(t *testing.T) {
 
 	o.Del("xx")
 
-	v, err := p.Parse(`{"fo\no": "bar", "x": [1,2,3]}`)
+	v, err := p.Parse(`{"fo\no": "bar", "x": [1,2,3]}`, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during parse: %s", err)
 	}
@@ -55,7 +55,7 @@ func TestObjectDelSet(t *testing.T) {
 
 func TestValueDelSet(t *testing.T) {
 	var p Parser
-	v, err := p.Parse(`{"xx": 123, "x": [1,2,3]}`)
+	v, err := p.Parse(`{"xx": 123, "x": [1,2,3]}`, nil)
 	if err != nil {
 		t.Fatalf("unexpected error during parse: %s", err)
 	}


### PR DESCRIPTION
no skip

BenchmarkSkip/fastjson
BenchmarkSkip/fastjson-16         	   10000	    557511 ns/op	3098.06 MB/s	   31805 B/op	      49 allocs/op
BenchmarkSkip/fastjson-16         	   10000	    548662 ns/op	3148.03 MB/s	   29815 B/op	      46 allocs/op
BenchmarkSkip/fastjson-16         	   10000	    553434 ns/op	3120.89 MB/s	   27828 B/op	      42 allocs/op

skip performance

BenchmarkSkip/fastjson
BenchmarkSkip/fastjson-16         	   10000	    323705 ns/op	5335.73 MB/s	    4144 B/op	       4 allocs/op
BenchmarkSkip/fastjson-16         	   10000	    311168 ns/op	5550.72 MB/s	    3887 B/op	       3 allocs/op
BenchmarkSkip/fastjson-16         	   10000	    305078 ns/op	5661.51 MB/s	    3630 B/op	       3 allocs/op